### PR TITLE
Enable extglob for whitespace trimming

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -39,6 +39,7 @@ jobs:
           MULTI_REPO_TOKEN: ${{ secrets.JUXTA_REPO_PERMISSION }}
         run: |
           set -euo pipefail
+          shopt -s extglob
           while IFS= read -r repo || [[ -n $repo ]]; do
             # Trim whitespace and ignore blanks / comments
             repo="${repo//$'\r'/}"


### PR DESCRIPTION
## Summary
- enable `extglob` in juxta-repo-arrange workflow to support whitespace trimming

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bash -c 'shopt -s extglob; while IFS= read -r repo || [[ -n $repo ]]; do repo="${repo//$'\r'/}"; repo="${repo##*( )}"; repo="${repo%%*( )}"; if [[ -z "$repo" || "$repo" =~ ^# ]]; then echo "skip: [$repo]"; else echo "process: [$repo]"; fi; done < /tmp/sample.txt'`

------
https://chatgpt.com/codex/tasks/task_b_68a55ac9464c8325933a04e36283ec4b