### PR TITLE
Use find to remove .git directories safely

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -67,7 +67,7 @@ jobs:
 
       # 5 – Strip Git metadata so only a snapshot remains
       - name: Remove Git metadata from clones
-        run: rm -rf repository/*/.git
+        run: find repository -name .git -type d -prune -exec rm -rf '{}' +
 
       # 6 – Commit the fresh snapshots back to this repo
       - name: Commit cloned repos


### PR DESCRIPTION
## Summary
- replace `rm -rf repository/*/.git` with a `find` command to reliably strip Git metadata, even when repository names contain spaces

## Testing
- `find temp/repository -name .git -type d -prune -exec rm -rf '{}' +`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a55f48b8548325abf9949aaf4007af