### PR TITLE
Use repository-scoped git config in cleanup workflow

### DIFF
--- a/.github/workflows/juxta-repo-cleanup.yml
+++ b/.github/workflows/juxta-repo-cleanup.yml
@@ -1,5 +1,6 @@
 name: juxta-repo-cleanup
-# Replaces README.md with SETTINGS.md and removes LICENSE.md, juxta-repo.jpg and repository/
+# Replaces README.md with SETTINGS.md
+# and removes LICENSE.md, juxta-repo.jpg and repository/
 
 on:
   workflow_dispatch:
@@ -31,10 +32,11 @@ jobs:
 
       - name: Commit and push changes
         run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
           git add -A
-          git commit -m "Update README.md from SETTINGS.md" || echo "No changes to commit"
+          git commit -m "Update README.md from SETTINGS.md" \
+            || echo "No changes to commit"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- avoid modifying global git state by configuring cleanup job locally
- wrap long lines and split introductory comment for yamllint

## Testing
- `yamllint .github/workflows/juxta-repo-cleanup.yml`

------
https://chatgpt.com/codex/tasks/task_b_68a563be741883258ec676cfc458627d