### PR TITLE
Use credential helper for repo cloning

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -40,6 +40,18 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s extglob
+
+          export GIT_ASKPASS="$(mktemp)"
+          cat > "$GIT_ASKPASS" <<'EOF'
+#!/bin/sh
+case "$1" in
+  Username*) echo "x-access-token" ;;
+  Password*) echo "$MULTI_REPO_TOKEN" ;;
+esac
+EOF
+          chmod +x "$GIT_ASKPASS"
+          export GIT_TERMINAL_PROMPT=0
+
           while IFS= read -r repo || [[ -n $repo ]]; do
             # Trim whitespace and ignore blanks / comments
             repo="${repo//$'\r'/}"
@@ -53,16 +65,14 @@ jobs:
               url="https://github.com/$repo.git"
             fi
 
-            # Inject PAT for authentication
-            auth_url="${url/https:\/\//https:\/\/x-access-token:${MULTI_REPO_TOKEN}@}"
-
             # Clone into repository/<repo‑name>
             target="repository/$(basename "$url" .git)"
             echo "➤ Cloning $url → $target"
-            git clone --depth 1 "$auth_url" "$target" || {
-              echo "❌ Failed to clone $repo"
+            if ! output=$(git clone --depth 1 "$url" "$target" 2>&1); then
+              echo "$output" | sed 's/'"$MULTI_REPO_TOKEN"'/[REDACTED]/g' >&2
+              echo "❌ Failed to clone $repo" >&2
               continue
-            }
+            fi
           done < .github/juxta-repo.txt
 
       # 5 – Strip Git metadata so only a snapshot remains


### PR DESCRIPTION
## Summary
- avoid embedding secrets in clone URLs by using a GIT_ASKPASS helper
- redact token from clone failures so logs don't leak secrets

## Testing
- `npx --yes actionlint .github/workflows/juxta-repo-arrange.yml` *(fails: could not determine executable to run)*
- `npm test` *(fails: Could not read package.json)*
- manual test: `git clone` failure redacted token

------
https://chatgpt.com/codex/tasks/task_b_68a563b9c79083259fd88f33267c5d8d