### PR TITLE
Handle empty block when sorting list items

### DIFF
--- a/repository/awesome-python/sort.py
+++ b/repository/awesome-python/sort.py
@@ -63,7 +63,10 @@ def main():
 
         if any([s_line.startswith(s) for s in ['* [', '- [']]):
             if indent == last_indent:
-                blocks[-1].append(line)
+                if not blocks:
+                    blocks.append([line])
+                else:
+                    blocks[-1].append(line)
             else:
                 blocks.append([line])
             last_indent = indent

--- a/repository/awesome-python/tests/test_sort.py
+++ b/repository/awesome-python/tests/test_sort.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure module import from repository/awesome-python directory
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+import sort
+
+
+def test_main_handles_file_starting_with_list_item(tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    readme.write_text("* [B Item](https://example.com/b)\n* [a Item](https://example.com/a)\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sort, "sort_blocks", lambda: None)
+
+    sort.main()
+
+    assert readme.read_text() == "* [a Item](https://example.com/a)\n* [B Item](https://example.com/b)\n"


### PR DESCRIPTION
## Summary
- Safeguard `sort.py` against referencing a non-existent block when the file starts with a list item
- Add pytest to verify sorting with README files that begin with list entries

## Testing
- `pytest repository/awesome-python/tests/test_sort.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a56b0ced1c8325b39511630b2a2045