### PR TITLE
Ensure juxta-repo-cleanup pushes only after successful commit

### DIFF
--- a/.github/workflows/juxta-repo-cleanup.yml
+++ b/.github/workflows/juxta-repo-cleanup.yml
@@ -35,13 +35,17 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and push changes
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add -A
-          git commit -m "Update README.md from SETTINGS.md" \
-            || echo "No changes to commit"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: Commit and push changes
+          run: |
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add -A
+            if git commit -m "Update README.md from SETTINGS.md"; then
+              git diff --cached --quiet
+              git push
+            else
+              git diff --cached --quiet
+              echo "No changes to commit"
+            fi
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Only push cleanup changes when commit succeeds and index is clean

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a692de37888325baadf20daa3ec60b