### PR TITLE
chore: fetch full history in workflows

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: true
 
       - name: Ensure .github/juxta-repo.txt has Unix line endings

--- a/.github/workflows/juxta-repo-clear.yml
+++ b/.github/workflows/juxta-repo-clear.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: true
 
       - name: Remove repository directory


### PR DESCRIPTION
## Summary
- run checkout with full history in juxta-repo-arrange
- run checkout with full history in juxta-repo-clear

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a695944a048325b5f4451ddd9749f4