### PR TITLE
fix: keep AI badge on single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [**juxta-repo**](https://github.com/japertechnology/juxta-repo)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) ![AI](https://img.shields.io/badge/Assisted-Development-2b2bff?logo=openai&logoColor=white) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) ![AI](https://img.shields.io/badge/Assisted-Development-2b2bff?logo=openai&logoColor=white)
 
 Captures the latest GitHub snapshots of [**specified**](.github/juxta-repo.txt) repositories, places them [**side-by-side**](repository/), static and untouched, enabling analysis and comparison without merging or preserving history.
 


### PR DESCRIPTION
## Summary
- keep AI badge in README on a single line

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a80c79230883258f5d7308eeab3ae1