### PR TITLE
chore: pin actions/checkout to commit hash

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/juxta-repo-cleanup.yml
+++ b/.github/workflows/juxta-repo-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Rename SETTINGS.md to README.md
         run: |

--- a/.github/workflows/juxta-repo-clear.yml
+++ b/.github/workflows/juxta-repo-clear.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
           persist-credentials: true


### PR DESCRIPTION
## Summary
- pin actions/checkout to latest v4 commit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b64732aa548325a52e3809cc66aea9