### PR TITLE
Validate repository list before cloning

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -35,6 +35,11 @@ jobs:
           [ -d repository ] && ! [ -L repository ] || { echo "Safety check failed"; exit 1; }
           rm -rf repository/* repository/.[!.]* repository/..?*   # start from a clean slate
 
+      - name: Validate repository list
+        env:
+          MULTI_REPO_TOKEN: ${{ secrets.JUXTA_REPO_PERMISSION }}
+        run: scripts/validate-repos.sh .github/juxta-repo.txt
+
       - name: Shallow‑clone every repo in juxta-repo.txt
         env:
           MULTI_REPO_TOKEN: ${{ secrets.JUXTA_REPO_PERMISSION }}

--- a/scripts/validate-repos.sh
+++ b/scripts/validate-repos.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s extglob
+
+FILE="${1:-.github/juxta-repo.txt}"
+ALLOWED="${OWNER_ALLOWLIST:-}"
+MAX_SIZE="${MAX_REPO_SIZE_KB:-}"
+TOKEN="${MULTI_REPO_TOKEN:-${GITHUB_TOKEN:-}}"
+
+failed=0
+
+while IFS= read -r line || [[ -n $line ]]; do
+  line="${line//$'\r'/}"
+  line="${line##*( )}"
+  line="${line%%*( )}"
+  [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+  if [[ $line =~ ^https?://github.com/([^/]+)/([^/]+?)(\.git)?$ ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+  elif [[ $line =~ ^[^/]+/[^/]+$ ]]; then
+    owner="${line%%/*}"
+    repo="${line##*/}"
+  else
+    echo "Invalid repository format: $line" >&2
+    failed=1
+    continue
+  fi
+
+  if [[ -n "$ALLOWED" ]]; then
+    IFS=',' read -ra allowed_arr <<< "${ALLOWED// /,}"
+    allowed_ok=0
+    for o in "${allowed_arr[@]}"; do
+      [[ "$o" == "$owner" ]] && allowed_ok=1 && break
+    done
+    if [[ $allowed_ok -eq 0 ]]; then
+      echo "Owner '$owner' is not in allowlist" >&2
+      failed=1
+      continue
+    fi
+  fi
+
+  if [[ -n "$TOKEN" ]]; then
+    api_url="https://api.github.com/repos/$owner/$repo"
+    resp=$(curl -fsSL -H "Authorization: Bearer $TOKEN" "$api_url") || {
+      echo "Repository $owner/$repo not found or inaccessible" >&2
+      failed=1
+      continue
+    }
+    if [[ -n "$MAX_SIZE" ]]; then
+      size=$(echo "$resp" | grep -oE '"size":\s*[0-9]+' | head -1 | grep -oE '[0-9]+')
+      if [[ -n "$size" && "$size" -gt "$MAX_SIZE" ]]; then
+        echo "Repository $owner/$repo size ${size}KB exceeds limit ${MAX_SIZE}KB" >&2
+        failed=1
+      fi
+    fi
+  fi
+
+done < "$FILE"
+
+if [[ $failed -ne 0 ]]; then
+  echo "Repository validation failed" >&2
+  exit 1
+fi
+
+echo "Repository validation passed"


### PR DESCRIPTION
## Summary
- add `scripts/validate-repos.sh` for format checking and optional GitHub API validation of repos
- run the validation script in `juxta-repo-arrange` workflow before cloning

## Testing
- `scripts/validate-repos.sh .github/juxta-repo.txt`

------
https://chatgpt.com/codex/tasks/task_b_68b64a42d7448325860594b56492f3a9