### PR TITLE
Add validation for repository list entries

### DIFF
--- a/.github/workflows/juxta-repo-validate.yml
+++ b/.github/workflows/juxta-repo-validate.yml
@@ -1,0 +1,28 @@
+name: juxta-repo-validate
+
+on:
+  push:
+    paths:
+      - '.github/juxta-repo.txt'
+  pull_request:
+    paths:
+      - '.github/juxta-repo.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Validate repository list
+        run: scripts/validate-repos.sh .github/juxta-repo.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Captures the latest GitHub snapshots of [**specified**](.github/juxta-repo.txt) 
 
 [**.github/juxta-repo.txt**](.github/juxta-repo.txt) contains the list of repositories to arrange, each on its own line using the format: `owner/repository` and when committed arrangements will be made.
 
+[**scripts/validate-repos.sh**](scripts/validate-repos.sh) verifies that every non-comment line uses either `owner/repository` or a full `https://github.com/owner/repository` URL. The [**juxta-repo-validate**](.github/workflows/juxta-repo-validate.yml) workflow runs this check and reports the line number of any malformed entry. You can run the script locally with `scripts/validate-repos.sh .github/juxta-repo.txt` before committing.
+
 [**.github/workflows/juxta-repo-arrange**](.github/workflows/juxta-repo-arrange.yml) clones the repositories listed in `.github/juxta-repo.txt` file into a fresh `repository/` directory. Each target repository appears as a subfolder holding a snapshot of its files with no Git history.
  
 [**.github/workflows/juxta-repo-clear**](.github/workflows/juxta-repo-clear.yml) deletes the `repository/` directory.


### PR DESCRIPTION
## Summary
- report line numbers for malformed entries in `scripts/validate-repos.sh`
- add `juxta-repo-validate` workflow to check `.github/juxta-repo.txt`
- document repository list validation in `README.md`

## Testing
- `scripts/validate-repos.sh .github/juxta-repo.txt`


------
https://chatgpt.com/codex/tasks/task_b_68b6552a3f30832590d5036aa42dcfc3