### PR TITLE
Schedule weekly snapshot refresh and prune old snapshots

### DIFF
--- a/.github/workflows/juxta-repo-arrange.yml
+++ b/.github/workflows/juxta-repo-arrange.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - '.github/juxta-repo.txt'
+  schedule:
+    - cron: '0 0 * * 0' # weekly refresh
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/juxta-repo-prune.yml
+++ b/.github/workflows/juxta-repo-prune.yml
@@ -1,0 +1,40 @@
+name: juxta-repo-prune
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # weekly at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Prune stale snapshots
+        run: scripts/prune-snapshots.sh
+        env:
+          SNAPSHOT_RETENTION_DAYS: 30
+
+      - name: Commit pruned snapshots
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add repository
+          if git diff --cached --quiet; then
+            echo "✨ No snapshots to prune"
+          else
+            git commit -m "Prune snapshots older than ${SNAPSHOT_RETENTION_DAYS:-30} days"
+            git push
+          fi

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -2,8 +2,10 @@
 
 [**Edit**](.github/juxta-repo.txt) the list, owner/repo, one repo per line.
 
-[**Arrange**](.github/workflows/juxta-repo-arrange.yml) creates and populates the [**repository**](repository/) directory.
+[**Arrange**](.github/workflows/juxta-repo-arrange.yml) creates and populates the [**repository**](repository/) directory each week to refresh snapshots.
 
 [**Clear**](.github/workflows/juxta-repo-clear.yml) deletes the [**repository**](repository/) directory.
+
+[**Prune**](.github/workflows/juxta-repo-prune.yml) runs weekly to remove snapshots in [**repository**](repository/) older than the `SNAPSHOT_RETENTION_DAYS` threshold (default 30 days).
 
 Private repo cloning requires a [**GitHub Personal Access Token**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens), [**fine-grained**](https://github.com/settings/personal-access-tokens) or [**classic**](https://github.com/settings/tokens), to be maintained in a [**Repo Secret**](https://github.com/japertechnology/juxta-repo/settings/secrets/actions) called **JUXTA_REPO_PERMISSION**.

--- a/scripts/prune-snapshots.sh
+++ b/scripts/prune-snapshots.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove snapshots in the repository/ directory older than a retention period.
+# Default retention is 30 days; override with SNAPSHOT_RETENTION_DAYS environment variable.
+
+RETENTION_DAYS="${SNAPSHOT_RETENTION_DAYS:-30}"
+SNAPSHOT_DIR="repository"
+
+# Ensure directory exists and isn't a symlink for safety.
+if [[ ! -d "$SNAPSHOT_DIR" || -L "$SNAPSHOT_DIR" ]]; then
+  echo "Snapshot directory '$SNAPSHOT_DIR' missing or is a symlink; nothing to prune." >&2
+  exit 0
+fi
+
+find "$SNAPSHOT_DIR" -mindepth 1 -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -print0 | while IFS= read -r -d '' dir; do
+  echo "Pruning snapshot: $dir (older than $RETENTION_DAYS days)"
+  rm -rf "$dir"
+done


### PR DESCRIPTION
## Summary
- run `juxta-repo-arrange` weekly to refresh repository snapshots
- add pruning workflow to delete stale snapshots older than 30 days
- document retention policy in SETTINGS

## Testing
- `bash scripts/prune-snapshots.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b656d39ea083258a6aa9829ba3bb6e